### PR TITLE
chore: remove useless sudo prefix command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ make clean
 2. Clone your forked project locally
 
 ```
-$ sudo git clone https://github.com/your_repo/generator-go.git
+$ git clone https://github.com/your_repo/generator-go.git
 $ cd generator-go
 ```
 


### PR DESCRIPTION
close #4 


## Background/Issue

There was a useless sudo prefixing the `git clone` command in the README.md.

When you run git using sudo, git will run as root. Because git is running as root, ssh is running as root. Because ssh is running as root, it is trying to log on to the remote server as root. And this leads to authent issues and more...

## Proposal

Just remove it.